### PR TITLE
Fix player chunk loading after scatter

### DIFF
--- a/src/main/java/cc/kasumi/uhc/util/GameUtil.java
+++ b/src/main/java/cc/kasumi/uhc/util/GameUtil.java
@@ -763,10 +763,23 @@ public class GameUtil {
         int x = location.getBlockX();
         int z = location.getBlockZ();
 
-        // Ensure destination chunk is loaded
-        Chunk chunk = world.getChunkAt(x >> 4, z >> 4);
-        if (!chunk.isLoaded()) {
-            chunk.load(true);
+        // Check if near a scatter location and preload appropriately
+        try {
+            if (ProgressiveScatterManager.isNearScatterLocation(location)) {
+                ProgressiveScatterManager.preloadScatterChunks(location);
+            } else {
+                // Ensure destination chunk is loaded
+                Chunk chunk = world.getChunkAt(x >> 4, z >> 4);
+                if (!chunk.isLoaded()) {
+                    chunk.load(true);
+                }
+            }
+        } catch (Exception e) {
+            // Fallback to basic chunk loading if scatter manager fails
+            Chunk chunk = world.getChunkAt(x >> 4, z >> 4);
+            if (!chunk.isLoaded()) {
+                chunk.load(true);
+            }
         }
 
         // Calculate safe Y coordinate

--- a/src/main/java/cc/kasumi/uhc/util/ProgressiveScatterManager.java
+++ b/src/main/java/cc/kasumi/uhc/util/ProgressiveScatterManager.java
@@ -855,45 +855,12 @@ public class ProgressiveScatterManager extends BukkitRunnable {
             }
         }
         
-        // Store scatter chunks for future reference instead of unloading immediately
+        // Store scatter chunks for future reference to help with teleportation
         String worldKey = world.getName();
         worldScatterChunks.put(worldKey, new HashSet<>(preloadedChunks));
         
-        // Keep chunks loaded for much longer (5 minutes instead of 10 seconds)
-        // This helps prevent chunk loading issues when players teleport to scattered locations
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                Set<ChunkCoordinate> scatterChunks = worldScatterChunks.get(worldKey);
-                if (scatterChunks != null) {
-                    int unloadedCount = 0;
-                    for (ChunkCoordinate coord : scatterChunks) {
-                        Chunk chunk = world.getChunkAt(coord.x, coord.z);
-                        if (chunk.isLoaded()) {
-                            // Only unload if no players are nearby (within 3 chunks)
-                            boolean playersNearby = false;
-                            for (Player player : world.getPlayers()) {
-                                Chunk playerChunk = player.getLocation().getChunk();
-                                if (Math.abs(playerChunk.getX() - coord.x) <= 3 && 
-                                    Math.abs(playerChunk.getZ() - coord.z) <= 3) {
-                                    playersNearby = true;
-                                    break;
-                                }
-                            }
-                            
-                            if (!playersNearby) {
-                                chunk.unload(true);
-                                unloadedCount++;
-                            }
-                        }
-                    }
-                    UHC.getInstance().getLogger().info("Unloaded " + unloadedCount + " scatter chunks (kept chunks with nearby players loaded)");
-                    
-                    // Clean up after unloading
-                    worldScatterChunks.remove(worldKey);
-                }
-            }
-        }.runTaskLater(UHC.getInstance(), 6000L); // Unload after 5 minutes instead of 10 seconds
+        UHC.getInstance().getLogger().info("Scatter chunks stored for future teleportation assistance. " +
+                "Server will handle chunk unloading naturally.");
     }
     
     /**


### PR DESCRIPTION
Improve chunk loading for scattered players by removing aggressive unloading and enhancing teleportation chunk preloading.

The previous `ProgressiveScatterManager` aggressively unloaded preloaded chunks after 10 seconds. This led to players falling through blocks when teleporting to scattered locations after the initial scatter phase, as those chunks were no longer loaded. This PR removes the forced unloading and introduces a system to track scatter locations, allowing `PlayerListener` and `GameUtil.safeTeleport` to intelligently preload a 5x5 chunk area when a player teleports near a previously scattered location, ensuring chunks are loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8d3d8c6-928b-438a-ab60-c9b74e83cb13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8d3d8c6-928b-438a-ab60-c9b74e83cb13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

